### PR TITLE
Add january parties

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -20,6 +20,7 @@ module.exports = (eleventyConfig) => {
 
   let markdown = markdownIt({
     typographer: true,
+    html: true,
   });
 
   markdown.use(emoji);

--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -1,22 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title>{{ title }} | Lunch.dev Community Calendar</title>
-</head>
-<body>
-	{% include partials/header.html %}
-	<main>
-		<h1>{{ title }}</h1>
-		{% if speakers %}
-		<ul>
-			{% for speaker in speakers %}
-			<li>{{ speaker }}</li>
-			{% endfor %}
-		</ul>
-		{% endif %}
-		{{ content }}
-	</main>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{ title }} | Lunch.dev Community Calendar</title>
+  </head>
+  <body>
+    {% include partials/header.html %}
+    <main>
+      <h1>{{ title }}</h1>
+      {% if speakers %}
+      <ul>
+        {% for speaker in speakers %}
+        <li>{{ speaker }}</li>
+        {% endfor %}
+      </ul>
+      {% endif %} {{ content }}
+      <p>Join this event <a href="https://discord.com/invite/q9ZdBgP">in Discord</a></p>
+    </main>
+  </body>
 </html>

--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -3,20 +3,24 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>{{ title }} | Lunch.dev Community Calendar</title>
+    <link rel="stylesheet" href="/css/reset.css" />
+    <link rel="stylesheet" href="/css/styles.css" />
+    <title>{{ title }}{% if type %}, {{type}}{% endif %} | Lunch.dev Community Calendar</title>
   </head>
-  <body>
-    {% include partials/header.html %}
-    <main>
-      <h1>{{ title }}</h1>
-      {% if speakers %}
-      <ul>
-        {% for speaker in speakers %}
-        <li>{{ speaker }}</li>
-        {% endfor %}
-      </ul>
-      {% endif %} {{ content }}
-      <p>Join this event <a href="https://discord.com/invite/q9ZdBgP">in Discord</a></p>
-    </main>
+  <body data-typeface="system-ui">
+    <div data-layout="centered-single-column">
+      {% include partials/header.html %}
+      <main>
+        <h1>{{ title }}</h1>
+        {% if speakers %}
+        <ul>
+          {% for speaker in speakers %}
+          <li>{{ speaker }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %} {{ content }}
+        <p>Join this event <a href="https://discord.com/invite/q9ZdBgP">in Discord</a></p>
+      </main>
+    </div>
   </body>
 </html>

--- a/src/_includes/layouts/homepage.html
+++ b/src/_includes/layouts/homepage.html
@@ -11,8 +11,8 @@
     <main data-layout="centered-single-column">
       <h1>Lunch.dev Community Calendar</h1>
 
-      <h2>Upcoming Events</h2>
-      <ul>
+      <h2 id="upcoming-events-section">Upcoming Events</h2>
+      <ul aria-labelledby="upcoming-events-section">
         {% for event in collections.upcomingEvents %} {{ event | log }}
         <li>
           <a href="{{ event.url }}"> {{ event.data.title }} </a>
@@ -23,8 +23,8 @@
         {% endfor %}
       </ul>
 
-      <h2>Past Events</h2>
-      <ul>
+      <h2 id="past-events-section">Past Events</h2>
+      <ul aria-labelledby="past-events-section">
         {% for event in collections.pastEvents %} {{ event | log }}
         <li>
           <a href="{{ event.url }}"> {{ event.data.title }} </a>

--- a/src/_includes/layouts/homepage.html
+++ b/src/_includes/layouts/homepage.html
@@ -10,13 +10,20 @@
   <body data-typeface="system-ui">
     <main data-layout="centered-single-column">
       <h1>Lunch.dev Community Calendar</h1>
+
+      <h2>Upcoming Events</h2>
       <ul>
         {% for event in collections.upcomingEvents %} {{ event | log }}
         <li>
           <a href="{{ event.url }}"> {{ event.data.title }} </a>
+          {% if event.data.type %}
+          <span>{{ event.data.type }}</span>
+          {% endif %}
         </li>
         {% endfor %}
       </ul>
+
+      <h2>Past Events</h2>
       <ul>
         {% for event in collections.pastEvents %} {{ event | log }}
         <li>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -14,3 +14,19 @@
 [data-layout='centered-single-column'] {
   padding: 0 calc(var(--mainPadding) / 2);
 }
+
+[data-responsive-youtube--container] {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: 56.25%;
+  margin: 1em 0;
+}
+
+[data-responsive-youtube--container] > iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/src/schedule/2021-01-14-data-fetching-with-server-components.md
+++ b/src/schedule/2021-01-14-data-fetching-with-server-components.md
@@ -1,0 +1,14 @@
+---
+title: Data Fetching With Server Components
+type: Episode Party
+date: 2021-01-14
+layout: layouts/event.html
+---
+
+Before the holidays, the React Core [announced React Server Components](https://it.reactjs.org/blog/2020/12/21/data-fetching-with-react-server-components.html).
+
+We'll watch and discuss this talk as a group.
+
+<div data-responsive-youtube--container>
+  <iframe src="https://www.youtube.com/embed/TQQPAU21ZUw" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</div>

--- a/src/schedule/2021-01-14-data-fetching-with-server-components.md
+++ b/src/schedule/2021-01-14-data-fetching-with-server-components.md
@@ -2,7 +2,6 @@
 title: Data Fetching With Server Components
 type: Episode Party
 date: 2021-01-14
-layout: layouts/event.html
 ---
 
 Before the holidays, the React Core [announced React Server Components](https://it.reactjs.org/blog/2020/12/21/data-fetching-with-react-server-components.html).

--- a/src/schedule/2021-01-19-hijacking-screenreaders-with-css.md
+++ b/src/schedule/2021-01-19-hijacking-screenreaders-with-css.md
@@ -1,5 +1,6 @@
 ---
 title: Hijacking Screenreaders with CSS
+type: Talk
 date: 2021-01-19
 speakers:
   - Ben Myers

--- a/src/schedule/2021-01-21-get-access-with-aaron-cannon.md
+++ b/src/schedule/2021-01-21-get-access-with-aaron-cannon.md
@@ -1,0 +1,21 @@
+---
+title: Get Access with Aaron Cannon
+type: Episode Party
+date: 2021-01-28
+layout: layouts/event.html
+---
+
+Live listen and discussion of Aaron Cannon's [React Podcast](https://reactpodcast.com) episode on accessibility.  
+This episode aired July 11th, 2019 but remains relevant to React developers today.
+
+## Episode Summary
+
+This week, we talk accessibility pitfalls with Aaron Canon.
+
+Aaron is the co-founder and chief accessibility engineer at Accessible360 — where he uses his experience as a blind developer to improve real-world accessibility for all citizens of the web.
+
+He shares his first-hand experience on which practices work, which ones are bogus, where to focus our accessibility efforts, and which libraries provide the best starting point.
+
+I learned a ton. You will too.
+
+<iframe height="200px" width="100%" frameborder="no" scrolling="no" seamless src="https://player.simplecast.com/3366f2b7-1e86-441b-b03e-1abc874cca11?dark=false"></iframe>

--- a/src/schedule/2021-01-21-get-access-with-aaron-cannon.md
+++ b/src/schedule/2021-01-21-get-access-with-aaron-cannon.md
@@ -2,7 +2,6 @@
 title: Get Access with Aaron Cannon
 type: Episode Party
 date: 2021-01-28
-layout: layouts/event.html
 ---
 
 Live listen and discussion of Aaron Cannon's [React Podcast](https://reactpodcast.com) episode on accessibility.  

--- a/src/schedule/2021-01-28-code-and-trust-with-saron-yitbarek.md
+++ b/src/schedule/2021-01-28-code-and-trust-with-saron-yitbarek.md
@@ -1,0 +1,19 @@
+---
+title: Code and Trust with Saron Yitbarek
+type: Episode Party
+date: 2021-01-28
+layout: layouts/event.html
+---
+
+Live listen and discussion of Saron Yitbarek's [React Podcast](https://reactpodcast.com) episode on the CodeNewbie community.  
+This episode aired May 30th, 2019 and remains relevant to React developers today.
+
+## Episode Summary
+
+Saron Yitbarek is the CEO and founder of CodeNewbie, the most supportive community of programmers and people learning to code. She's also the vibrant host of the CodeNewbie Podcast, Basecs Podcast, and Command Line Heroes (a Red Hat podcast).
+
+Chantastic Asks her about learning in public, interviewing the world’s greatest developers, the art of storytelling, and aggressive kindness that surround her #CodeNewbie twitter chats.
+
+They discuss podcasting, building a community you can trust, shower new developers with love and support, and what it takes to put on the most supportive conference in the world.
+
+<iframe height="200px" width="100%" frameborder="no" scrolling="no" seamless src="https://player.simplecast.com/69d510c0-60aa-4ea1-a5e7-d2bf514f5fd8?dark=false"></iframe>

--- a/src/schedule/2021-01-28-code-and-trust-with-saron-yitbarek.md
+++ b/src/schedule/2021-01-28-code-and-trust-with-saron-yitbarek.md
@@ -2,7 +2,6 @@
 title: Code and Trust with Saron Yitbarek
 type: Episode Party
 date: 2021-01-28
-layout: layouts/event.html
 ---
 
 Live listen and discussion of Saron Yitbarek's [React Podcast](https://reactpodcast.com) episode on the CodeNewbie community.  


### PR DESCRIPTION
Started intent on just adding the upcoming listen parties but got kinda sucked in.  
Left everything as individual commits. So we can peel anything out that we don't want.

Here's a summary of the non-event changes:

* `.eleventy.js`: enable HTML in markdown files (for embeds)
* `event.html`: add shared link to discord for all events
* `homepage.html`: add event "type". right now that's just `Episode Party` and `Talk`
* `styles.css`: add `data-responsive-youtube--container` selector for responsive embeds
* update all upcoming events with `type` frontmatter

## screenshots

<img width="686" alt="Screen Shot 2021-01-07 at 1 23 04 PM" src="https://user-images.githubusercontent.com/658360/103947102-6ca21e80-50ec-11eb-96bf-d8fc57818c2e.png">
<img width="686" alt="Screen Shot 2021-01-07 at 1 23 00 PM" src="https://user-images.githubusercontent.com/658360/103947114-6f9d0f00-50ec-11eb-80bd-8407bf5a48f9.png">
<img width="686" alt="Screen Shot 2021-01-07 at 1 22 53 PM" src="https://user-images.githubusercontent.com/658360/103947123-73309600-50ec-11eb-9c26-85eb03d5de9d.png">
<img width="686" alt="Screen Shot 2021-01-07 at 1 22 50 PM" src="https://user-images.githubusercontent.com/658360/103947130-74fa5980-50ec-11eb-8486-06c636ca9f17.png">
