### PR TITLE
Headers and headings

### DIFF
--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -5,11 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/css/reset.css" />
     <link rel="stylesheet" href="/css/styles.css" />
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@900&family=Source+Code+Pro:ital,wght@0,400;0,600;1,500;1,600&display=swap" rel="stylesheet">
     <title>{{ title }}{% if type %}, {{type}}{% endif %} | Lunch.dev Community Calendar</title>
   </head>
   <body data-typeface="system-ui">
+	{% include partials/header.html %}
     <div data-layout="centered-single-column">
-      {% include partials/header.html %}
       <main>
         <h1>{{ title }}</h1>
         {% if speakers %}

--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -14,15 +14,15 @@
 	{% include partials/header.html %}
     <div data-layout="centered-single-column">
       <main>
-        <h1>{{ title }}</h1>
-        {% if speakers %}
-        <ul>
-          {% for speaker in speakers %}
-          <li>{{ speaker }}</li>
-          {% endfor %}
-        </ul>
-        {% endif %} {{ content }}
+		<h1>{{ title }}</h1>
+		<small>
+			{% if speakers %}
+			{{ speakers | join: ', ' }} &middot; 
+			{% endif %}
+			{{ date }}
+		</small>
         <p>Join this event <a href="https://discord.com/invite/q9ZdBgP">in Discord</a></p>
+        {{ content }}
       </main>
     </div>
   </body>

--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/css/reset.css" />
     <link rel="stylesheet" href="/css/styles.css" />
+    <link rel="stylesheet" href="/css/navbar.css" />
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@900&family=Source+Code+Pro:ital,wght@0,400;0,600;1,500;1,600&display=swap" rel="stylesheet">
     <title>{{ title }}{% if type %}, {{type}}{% endif %} | Lunch.dev Community Calendar</title>

--- a/src/_includes/layouts/homepage.html
+++ b/src/_includes/layouts/homepage.html
@@ -5,9 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="css/reset.css" />
     <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="/css/navbar.css" />
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@900&family=Source+Code+Pro:ital,wght@0,400;0,600;1,500;1,600&display=swap" rel="stylesheet">
     <title>Lunch.dev Community Calendar</title>
   </head>
   <body data-typeface="system-ui">
+	{% include partials/header.html %}
     <main data-layout="centered-single-column">
       <h1>Lunch.dev Community Calendar</h1>
 

--- a/src/_includes/partials/header.html
+++ b/src/_includes/partials/header.html
@@ -1,4 +1,4 @@
-<header style="background-color: aquamarine;">
+<header id="navbar">
 	<nav>
 		<a href="/">Lunch.dev Community</a>
 	</nav>

--- a/src/css/navbar.css
+++ b/src/css/navbar.css
@@ -18,6 +18,10 @@
 }
 
 #navbar a:focus {
+	color: gold;
+}
+
+#navbar a:focus-visible {
 	outline: 2px solid gold;
 	outline-offset: 0.3em;
 }

--- a/src/css/navbar.css
+++ b/src/css/navbar.css
@@ -1,0 +1,23 @@
+#navbar {
+	width: 100%;
+	background-color: black;
+	padding: 1%;
+	margin-bottom: 1.5em;
+}
+
+#navbar a {
+	color: white;
+	font-weight: 900;
+	text-decoration: none;
+	font-family: 'Alegreya Sans', sans-serif;
+	font-size: 24pt;
+}
+
+#navbar a:hover {
+	color: gold;
+}
+
+#navbar a:focus {
+	outline: 2px solid gold;
+	outline-offset: 0.3em;
+}

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -11,6 +11,25 @@
   --mainPadding: calc(100% - var(--pageContentWidth));
 }
 
+#navbar {
+	width: 100%;
+	background-color: black;
+	padding: 1%;
+	margin-bottom: 1.5em;
+}
+
+#navbar a {
+	color: white;
+	font-weight: 900;
+	text-decoration: none;
+	font-family: 'Alegreya Sans', sans-serif;
+	font-size: 24pt;
+}
+
+#navbar a:hover {
+	color: gold;
+}
+
 [data-layout='centered-single-column'] {
   padding: 0 calc(var(--mainPadding) / 2);
 }

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -11,25 +11,6 @@
   --mainPadding: calc(100% - var(--pageContentWidth));
 }
 
-#navbar {
-	width: 100%;
-	background-color: black;
-	padding: 1%;
-	margin-bottom: 1.5em;
-}
-
-#navbar a {
-	color: white;
-	font-weight: 900;
-	text-decoration: none;
-	font-family: 'Alegreya Sans', sans-serif;
-	font-size: 24pt;
-}
-
-#navbar a:hover {
-	color: gold;
-}
-
 [data-layout='centered-single-column'] {
   padding: 0 calc(var(--mainPadding) / 2);
 }
@@ -48,4 +29,16 @@
   left: 0;
   width: 100%;
   height: 100%;
+}
+
+main > * + * {
+	margin-top: 1.5em;
+}
+
+h1, h2, h3, h4, h5, h6 {
+	font-family: 'Alegreya Sans', sans-serif;
+}
+
+h1 {
+	font-size: 40pt;
 }


### PR DESCRIPTION
Updated the navbar to have a more on-brand design than just a turquoise box.

Introduced the Alegreya Sans font for headings -- I'm totally game with this changing down the road, but in the meantime, I think this'll be fine for the sake of promoting the Hijacking Screenreaders talk.

Events now have subheading with their speakers and date.