### PR TITLE
Add Cloudinary social cards to event layout

### DIFF
--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -6,21 +6,22 @@
     <link rel="stylesheet" href="/css/reset.css" />
     <link rel="stylesheet" href="/css/styles.css" />
     <link rel="stylesheet" href="/css/navbar.css" />
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@900&family=Source+Code+Pro:ital,wght@0,400;0,600;1,500;1,600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Alegreya+Sans:wght@900&family=Source+Code+Pro:ital,wght@0,400;0,600;1,500;1,600&display=swap"
+      rel="stylesheet"
+    />
     <title>{{ title }}{% if type %}, {{type}}{% endif %} | Lunch.dev Community Calendar</title>
+    <meta property="description" content="{% if description %}{{description}}{% endif %}" />
+    <meta property="og:title" content="{{ title }}{% if type %}, {{type}}{% endif %} | Lunch.dev Community Calendar" />
+    <meta property="og:description" content="{{ date }} — {% if description %}{{description}}{% endif %}" />
   </head>
   <body data-typeface="system-ui">
-	{% include partials/header.html %}
+    {% include partials/header.html %}
     <div data-layout="centered-single-column">
       <main>
-		<h1>{{ title }}</h1>
-		<small>
-			{% if speakers %}
-			{{ speakers | join: ', ' }} &middot; 
-			{% endif %}
-			{{ date }}
-		</small>
+        <h1>{{ title }}</h1>
+        <small> {% if speakers %} {{ speakers | join: ', ' }} &middot; {% endif %} {{ date }} </small>
         {{ content }}
         <p>Join this event <a href="https://discord.com/invite/q9ZdBgP">in Discord</a></p>
       </main>

--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -16,6 +16,11 @@
     <meta property="og:title" content="{{ title }}{% if type %}, {{type}}{% endif %} | Lunch.dev Community Calendar" />
     <meta property="og:description" content="{{ date }} — {% if description %}{{description}}{% endif %}" />
     <meta property="og:type" content="article" />
+    <meta
+      property="og:image"
+      content="https://res.cloudinary.com/chantastic/image/upload/l_text:Roboto_100_bold:lunch.dev/v1610689497/white-twitter-card_rrnh0v.jpg"
+    />
+    <meta property="og:image:alt" content="lunch.dev" />
   </head>
   <body data-typeface="system-ui">
     {% include partials/header.html %}

--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -21,6 +21,7 @@
       content="https://res.cloudinary.com/chantastic/image/upload/l_text:Roboto_100_bold:lunch.dev/v1610689497/white-twitter-card_rrnh0v.jpg"
     />
     <meta property="og:image:alt" content="lunch.dev" />
+    <meta property="twitter:card" content="summary_large_image" />
   </head>
   <body data-typeface="system-ui">
     {% include partials/header.html %}

--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -15,6 +15,7 @@
     <meta property="description" content="{% if description %}{{description}}{% endif %}" />
     <meta property="og:title" content="{{ title }}{% if type %}, {{type}}{% endif %} | Lunch.dev Community Calendar" />
     <meta property="og:description" content="{{ date }} — {% if description %}{{description}}{% endif %}" />
+    <meta property="og:type" content="article" />
   </head>
   <body data-typeface="system-ui">
     {% include partials/header.html %}

--- a/src/schedule/2021-01-15-add-social-cards-to-eleventy-site.md
+++ b/src/schedule/2021-01-15-add-social-cards-to-eleventy-site.md
@@ -1,5 +1,6 @@
 ---
 title: Add Social Cards to an Eleventy Site
+description: We'll be adding them to the Eleventy site but the knowledge is totally transferrable to other places on the web.
 type: Mob Job
 date: 2021-01-19 18:00:00
 speakers:


### PR DESCRIPTION
A preview of events with `title` and `description` look like after todays event:

![image](https://user-images.githubusercontent.com/658360/104767842-ab099000-5721-11eb-8d74-2743ba207922.png)

A preview of events with `title`-only:

![image](https://user-images.githubusercontent.com/658360/104768046-e0ae7900-5721-11eb-8584-a0c227978408.png)
