### PR TITLE
Add /discord route with invite redirect

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -53,6 +53,7 @@ module.exports = (eleventyConfig) => {
 
 	eleventyConfig.addPassthroughCopy('src/assets');
 	eleventyConfig.addPassthroughCopy('src/css');
+	eleventyConfig.addPassthroughCopy('_redirects');
 
 	eleventyConfig.addFilter('asDateOnly', function (date) {
 		return format(new Date(date), 'PP');

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📅 Lunch.dev Community Calendar
 
-Welcome to the **Lunch.dev Community Calendar**! This site shows off all of the cool things we've been doing in our [Discord community](https://discord.gg/dx7ZWCy). It's built with a static site generator called [Eleventy](https://11ty.dev).
+Welcome to the **Lunch.dev Community Calendar**! This site shows off all of the cool things we've been doing in our [Discord community](https://https://events.lunch.dev/discord). It's built with a static site generator called [Eleventy](https://11ty.dev).
 
 ## Sounds great! How do I run it?
 
@@ -30,4 +30,4 @@ Then navigate to [localhost:8080](http://localhost:8080) to see the site.
 
 ## Can I contribute?
 
-Absolutely! We're using this community calendar as a way to learn these tools together, and that means open-sourcing it! We'll have more contribution information later, but in the meantime, if you have an idea for improvements, reach out [on the server](https://discord.gg/dx7ZWCy).
+Absolutely! We're using this community calendar as a way to learn these tools together, and that means open-sourcing it! We'll have more contribution information later, but in the meantime, if you have an idea for improvements, reach out [on the server](https://https://events.lunch.dev/discord).

--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,1 @@
+/discord https://https://events.lunch.dev/discord

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,1 @@
-/discord https://https://events.lunch.dev/discord
+/discord https://events.lunch.dev/discord

--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,1 @@
-/discord https://events.lunch.dev/discord
+/discord https://discord.gg/dx7ZWCy

--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -31,7 +31,7 @@
 				<h1>{{ title }}</h1>
 				<small> {% if speakers %} {{ speakers | join: ', ' }} &middot; {% endif %} {{ date }} </small>
 				{{ addToCalendarList }} {{ content }}
-				<p>Join this event <a href="https://discord.com/invite/q9ZdBgP">in Discord</a></p>
+				<p>Join this event <a href="https://events.lunch.dev/discord">in Discord</a></p>
 			</main>
 		</div>
 	</body>


### PR DESCRIPTION
Create a `/discord` path for simple linking to events and for improved calendar items (url field).

* add `_redirects` file for Netlify
* add `/discord` redirect to invite url
* add config to place`_redirects` folder into `_site` on build
* update existing Discord invite links