### PR TITLE
Show past events in reverse chronological order on the homepage

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -36,10 +36,7 @@ module.exports = (eleventyConfig) => {
 
 		return collectionApi
 			.getFilteredByGlob('./src/schedule/*.md')
-			.filter(
-				(event) =>
-					isValidEvent(event) && (isAfter(new Date(event.data.date), new Date()) || isToday(new Date(event.data.date)))
-			);
+			.filter((event) => isValidEvent(event) && isAfter(new Date(event.data.date), new Date()));
 	});
 
 	let markdown = markdownIt({

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
 	"dependencies": {
 		"@11ty/eleventy": "^0.11.1",
 		"calendar-link": "^2.0.8",
+		"cross-env": "^7.0.3",
 		"date-fns": "^2.16.1",
 		"markdown-it": "^12.0.4",
 		"markdown-it-emoji": "^2.0.0",
-		"simple-icons": "^4.7.0",
-		"cross-env": "^7.0.3"
+		"simple-icons": "^4.7.0"
 	},
 	"devDependencies": {
 		"@sherby/eleventy-plugin-files-minifier": "^1.1.1",

--- a/src/_includes/layouts/homepage.html
+++ b/src/_includes/layouts/homepage.html
@@ -35,7 +35,7 @@
 
 			<h2 class="events-title">Past Events</h2>
 			<section id="past-events-section" class="events-section">
-				{% for event in collections.pastEvents %} {{ event | log }}
+				{% for event in collections.pastEvents reversed %} {{ event | log }}
 				<article aria-labelledby="{{ event.data.title | slug }}" class="event-item">
 					<h3 id="{{ event.data.title | slug }}">{{ event.data.title }}</h3>
 					<p class="fg1 block subtitle">


### PR DESCRIPTION
Things accomplished in this pull request:

- [X] **Display past events in reverse chronological order on the homepage.**

This means newer, more relevant stuff is up near the top, so it's easier to find.

- [X] **Remove `isToday` check from upcoming events collection.**

We now add the hour to the events' timestamps. This meant that an event could satisfy `isBefore` (and get added to past events) *and* `isToday` (and get added to upcoming events), leading to duplicates. Removing the `isToday` check from the upcoming event collection prevented duplicates.


- [X] **Re-establish `cross-env` as a dependency, which lets us run `npm run dev` again.**

`cross-env` is used in `npm run dev` to set up environment variables, but the package was recently unlisted from dependencies. This restores it, so that devs can install the package and run the repository.