### PR TITLE
Update site colors somewhat

### DIFF
--- a/src/css/homepage.css
+++ b/src/css/homepage.css
@@ -12,6 +12,7 @@
 	margin: 16px;
 	padding: 16px;
 	box-shadow: rgba(0, 0, 0, 0.11) 0px 1.2px 3.6px, rgba(0, 0, 0, 0.11) 0px 6.4px 14.4px;
+	background-color: white;
 
 	display: flex;
 	flex-direction: column;
@@ -46,8 +47,15 @@
 	opacity: 0.8;
 }
 
+.event-item a:focus-visible {
+	outline-color: #ba8d1c;
+	outline-offset: 5px;
+	outline-style: dotted;
+	outline-width: 2px;
+}
+
 #upcoming-events-section .event-item a {
-	background-color: #6fffe9;
+	background-color: gold;
 	color: black;
 }
 

--- a/src/css/homepage.css
+++ b/src/css/homepage.css
@@ -54,6 +54,10 @@
 	outline-width: 2px;
 }
 
+.event-item a:active {
+	transform: scaleX(0.95);
+}
+
 #upcoming-events-section .event-item a {
 	background-color: gold;
 	color: black;

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -11,6 +11,10 @@
 	--mainPadding: calc(100% - var(--pageContentWidth));
 }
 
+body {
+	background-color: #f5f5f5;
+}
+
 [data-layout='centered-single-column'] {
 	padding: 0 calc(var(--mainPadding) / 2);
 }


### PR DESCRIPTION
This pull request has a few style updates, namely:

- **Make upcoming events' _View Details_ links gold,** to lean into the gold theme.

- **Customize events' View Details links' focus outlines using `:focus-visible`.** Now, when a keyboard user tabs to any of the View Details links, their focus outline will be dark gold, and will have more padding.

- **Shrink View Details links a bit when they're being pressed (`:active`),** to give a slightly more tactile, three-dimensional effect

- **Changed site background to a very, very light gray.** This has the effect of making the white event cards and any white backgrounds in our embeds stand out more.