### PR TITLE
Create a contributors page sourced from .all-contributorsrc

### DIFF
--- a/src/_data/contributions.json
+++ b/src/_data/contributions.json
@@ -1,0 +1,129 @@
+{
+	"a11y": {
+		"name": "Accessibility",
+		"emoji": "♿️"
+	},
+	"audio": {
+		"name": "Audio",
+		"emoji": "🔊"
+	},
+	"blog": {
+		"name": "Blogging"
+	},
+	"bug": {
+		"name": "Bug Reports",
+		"emoji": "🐛"
+	},
+	"business": {
+		"name": "Business Development",
+		"emoji": "💼"
+	},
+	"code": {
+		"name": "Code",
+		"emoji": "💻"
+	},
+	"content": {
+		"name": "Content",
+		"emoji": "🖋"
+	},
+	"data": {
+		"name": "Data",
+		"emoji": "🔣"
+	},
+	"design": {
+		"name": "Design",
+		"emoji": "🎨"
+	},
+	"doc": {
+		"name": "Documentation",
+		"emoji": "📖"
+	},
+	"eventOrganizing": {
+		"name": "Event Organizing",
+		"emoji": "📋"
+	},
+	"example": {
+		"name": "Examples",
+		"emoji": "💡"
+	},
+	"financial": {
+		"name": "Financial Support",
+		"emoji": "💵"
+	},
+	"fundingFinding": {
+		"name": "Funding/Grant Finder",
+		"emoji": "🔍"
+	},
+	"ideas": {
+		"name": "Ideas & Planning",
+		"emoji": "🤔"
+	},
+	"infra": {
+		"name": "Infrastructure",
+		"emoji": "🚇"
+	},
+	"maintenance": {
+		"name": "Maintenance",
+		"emoji": "🚧"
+	},
+	"mentorship": {
+		"name": "Mentorship",
+		"emoji": "🧑‍🏫"
+	},
+	"platform": {
+		"name": "Platform",
+		"emoji": "📦"
+	},
+	"plugin": {
+		"name": "Plugins & Utility Libraries",
+		"emoji": "🔌"
+	},
+	"projectManagement": {
+		"name": "Project Management",
+		"emoji": "📆"
+	},
+	"question": {
+		"name": "Question Answerer",
+		"emoji": "💬"
+	},
+	"research": {
+		"name": "Research",
+		"emoji": "🔬"
+	},
+	"review": {
+		"name": "Reviewed Pull Requests",
+		"emoji": "👀"
+	},
+	"security": {
+		"name": "Security",
+		"emoji": "🛡️"
+	},
+	"tool": {
+		"name": "Tooling",
+		"emoji": "🔧"
+	},
+	"translation": {
+		"name": "Translation",
+		"emoji": "🌍"
+	},
+	"test": {
+		"name": "Tests",
+		"emoji": "⚠️"
+	},
+	"tutorial": {
+		"name": "Tutorials",
+		"emoji": "✅"
+	},
+	"talk": {
+		"name": "Talks",
+		"emoji": "📢"
+	},
+	"userTesting": {
+		"name": "User Testing",
+		"emoji": "📓"
+	},
+	"video": {
+		"name": "Videos",
+		"emoji": "📹"
+	}
+}

--- a/src/_data/contributors.js
+++ b/src/_data/contributors.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+
+const data = fs.readFileSync(`${process.cwd()}/.all-contributorsrc`, 'utf-8');
+const { contributors } = JSON.parse(data);
+contributors.sort((left, right) => left.name.localeCompare(right.name));
+
+module.exports = contributors;

--- a/src/contributors.liquid
+++ b/src/contributors.liquid
@@ -1,0 +1,20 @@
+---
+layout: 'layouts/page.html'
+---
+
+{% for contributor in contributors %}
+<article aria-labelledby="h-{{ contributor.login }}">
+	<img src="{{ contributor.avatar_url }}" alt="" />
+	<h2 id="h-{{ contributor.login }}">
+		<a href="{{ contributor.profile }}">{{ contributor.name }}</a>
+	</h2>
+	<ul>
+		{% for contribution in contributor.contributions %}
+		<li>
+			<span aria-hidden="true">{{ contributions[contribution].emoji }}</span>
+			<span>{{ contributions[contribution].name }}</span>
+		</li>
+		{% endfor %}
+	</ul>
+</article>
+{% endfor %}

--- a/src/contributors.liquid
+++ b/src/contributors.liquid
@@ -1,4 +1,5 @@
 ---
+title: Contributors
 layout: 'layouts/page.html'
 ---
 


### PR DESCRIPTION
Closes all-contributors/all-contributors#55

We built a contributors page together using [global data](https://www.11ty.dev/docs/data-global/) over a lunch session on Jan 29, 2021. You will be able to see this page at [events.lunch.dev/contributors](https://events.lunch.dev/contributors/).