### PR TITLE
Add /youtube redirect to lunchdev YouTube channel

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,1 +1,2 @@
 /discord https://discord.gg/dx7ZWCy
+/youtube https://www.youtube.com/channel/UCB5V77aiP0pz7RVbfQrbr7Q


### PR DESCRIPTION
Adds `events.lunch.dev/youtube` route, which points to the [lunchdev YouTube channel](https://www.youtube.com/channel/UCB5V77aiP0pz7RVbfQrbr7Q).