### PR TITLE
Add 'Next event' section to homepage

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -5,7 +5,7 @@ const getTwitchChannelEmbed = require('./src/utils/get-twitch-channel-embed');
 const getYouTubeVideoEmbed = require('./src/utils/get-youtube-video-embed');
 const personUtils = require('./src/utils/person');
 
-const { isAfter, isBefore, format } = require('date-fns');
+const { isAfter, isBefore, format, isToday } = require('date-fns');
 
 const isProduction = process.env.NODE_ENV === 'production';
 // It's value taken in scripts(package.json) returned boolean
@@ -16,6 +16,11 @@ const isValidEvent = (event) => isValidTitle(event.data.title);
 module.exports = (eleventyConfig) => {
 	eleventyConfig.addCollection('events', (collectionApi) => {
 		return collectionApi.getFilteredByGlob('./src/schedule/*.md');
+	});
+	eleventyConfig.addCollection('todaysEvents', (collectionApi) => {
+		return collectionApi
+			.getFilteredByGlob('./src/schedule/*.md')
+			.filter((event) => isValidEvent(event) && isToday(new Date(event.data.date)));
 	});
 	eleventyConfig.addCollection('pastEvents', (collectionApi) => {
 		return collectionApi

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -17,11 +17,6 @@ module.exports = (eleventyConfig) => {
 	eleventyConfig.addCollection('events', (collectionApi) => {
 		return collectionApi.getFilteredByGlob('./src/schedule/*.md');
 	});
-	eleventyConfig.addCollection('todaysEvents', (collectionApi) => {
-		return collectionApi
-			.getFilteredByGlob('./src/schedule/*.md')
-			.filter((event) => isValidEvent(event) && isToday(new Date(event.data.date)));
-	});
 	eleventyConfig.addCollection('pastEvents', (collectionApi) => {
 		return collectionApi
 			.getFilteredByGlob('./src/schedule/*.md')

--- a/src/_includes/layouts/homepage.html
+++ b/src/_includes/layouts/homepage.html
@@ -21,8 +21,8 @@
 	<body data-typeface="system-ui">
 		{% include partials/header.html %}
 		<main data-layout="centered-single-column">
-			<h2 class="events-title">Next event</h2>
-			<section id="next-event-section" class="events-section">
+			<h2 id="next-event" class="events-title">Next event</h2>
+			<section id="next-event-section" aria-labelledby="next-event" class="events-section">
 				{% assign nextEvent = collections.upcomingEvents | first %}
 				<article aria-labelledby="{{ nextEvent.data.title | slug }}" class="event-item">
 					<h3 id="{{ nextEvent.data.title | slug }}">{{ nextEvent.data.title }}</h3>

--- a/src/_includes/layouts/homepage.html
+++ b/src/_includes/layouts/homepage.html
@@ -21,6 +21,37 @@
 	<body data-typeface="system-ui">
 		{% include partials/header.html %}
 		<main data-layout="centered-single-column">
+			{% if collections.todaysEvents %}
+			<h2 class="events-title">Today</h2>
+			<section id="todays-events-section" class="events-section">
+				{% for event in collections.todaysEvents %}
+				<article aria-labelledby="{{ event.data.title | slug }}" class="event-item">
+					<h3 id="{{ event.data.title | slug }}">{{ event.data.title }}</h3>
+
+					<p class="fg1 block subtitle">
+						<span>{% if event.data.type %}{{ event.data.type }} &middot; {% endif %}</span>
+						<time datetime="{{event.data.date | toISOString }}">{{ event.data.date | asDateTime }}</time>
+					</p>
+
+					<ul
+						data-unstyled-list
+						data-flex-stack
+						style="--flex-stack--direction: row; --flex-stack--gap: 0.25rem"
+						class="event-item__speaker-list"
+					>
+						{% for speaker in event.data.speakers %}
+						<li>
+							<img data-avatar src="{{people[speaker] | personAvatar}}" alt="{{speaker}}" />
+						</li>
+						{% endfor %}
+					</ul>
+
+					<a href="{{ event.url }}" aria-label="View Details for {{ event.data.title }}">View Details &#8250;</a>
+				</article>
+				{% endfor %}
+			</section>
+			{% endif %}
+
 			<h2 class="events-title">Upcoming Events</h2>
 			<section id="upcoming-events-section" class="events-section">
 				{% for event in collections.upcomingEvents %}

--- a/src/_includes/layouts/homepage.html
+++ b/src/_includes/layouts/homepage.html
@@ -21,16 +21,15 @@
 	<body data-typeface="system-ui">
 		{% include partials/header.html %}
 		<main data-layout="centered-single-column">
-			{% if collections.todaysEvents %}
-			<h2 class="events-title">Today</h2>
-			<section id="todays-events-section" class="events-section">
-				{% for event in collections.todaysEvents %}
-				<article aria-labelledby="{{ event.data.title | slug }}" class="event-item">
-					<h3 id="{{ event.data.title | slug }}">{{ event.data.title }}</h3>
+			<h2 class="events-title">Next event</h2>
+			<section id="next-event-section" class="events-section">
+				{% assign nextEvent = collections.upcomingEvents | first %}
+				<article aria-labelledby="{{ nextEvent.data.title | slug }}" class="event-item">
+					<h3 id="{{ nextEvent.data.title | slug }}">{{ nextEvent.data.title }}</h3>
 
 					<p class="fg1 block subtitle">
-						<span>{% if event.data.type %}{{ event.data.type }} &middot; {% endif %}</span>
-						<time datetime="{{event.data.date | toISOString }}">{{ event.data.date | asDateTime }}</time>
+						<span>{% if nextEvent.data.type %}{{ nextEvent.data.type }} &middot; {% endif %}</span>
+						<time datetime="{{nextEvent.data.date | toISOString }}">{{ nextEvent.data.date | asDateTime }}</time>
 					</p>
 
 					<ul
@@ -39,22 +38,23 @@
 						style="--flex-stack--direction: row; --flex-stack--gap: 0.25rem"
 						class="event-item__speaker-list"
 					>
-						{% for speaker in event.data.speakers %}
+						{% for speaker in nextEvent.data.speakers %}
 						<li>
 							<img data-avatar src="{{people[speaker] | personAvatar}}" alt="{{speaker}}" />
 						</li>
 						{% endfor %}
 					</ul>
 
-					<a href="{{ event.url }}" aria-label="View Details for {{ event.data.title }}">View Details &#8250;</a>
+					<a href="{{ nextEvent.url }}" aria-label="View Details for {{ nextEvent.data.title }}"
+						>View Details &#8250;</a
+					>
 				</article>
-				{% endfor %}
 			</section>
-			{% endif %}
 
 			<h2 class="events-title">Upcoming Events</h2>
 			<section id="upcoming-events-section" class="events-section">
-				{% for event in collections.upcomingEvents %}
+				{% assign upcomingEvents = collections.upcomingEvents | slice: 1, collections.upcomingEvents.length %} {% for
+				event in upcomingEvents %}
 				<article aria-labelledby="{{ event.data.title | slug }}" class="event-item">
 					<h3 id="{{ event.data.title | slug }}">{{ event.data.title }}</h3>
 


### PR DESCRIPTION
Separating the next event is the first step in making a more engaging "next event" presentation.

We've duplicated the template so that everything can be changed without disruption to the other sections.

![image](https://user-images.githubusercontent.com/658360/122272374-55364100-ce95-11eb-9ef5-830dfdf9d854.png)
