### PR TITLE
add fathom analytics to all templates

### DIFF
--- a/src/_includes/layouts/event.html
+++ b/src/_includes/layouts/event.html
@@ -30,6 +30,7 @@
 		<meta property="og:image:alt" content="lunch.dev" />
 		<meta property="twitter:card" content="summary_large_image" />
 		<script src="/js/localize-dates.js" defer></script>
+		{% include partials/analytics.html %}
 	</head>
 	<body data-typeface="system-ui">
 		{% include partials/header.html %}

--- a/src/_includes/layouts/homepage.html
+++ b/src/_includes/layouts/homepage.html
@@ -17,6 +17,7 @@
 		/>
 		<title>Lunch.dev Community Calendar</title>
 		<script src="/js/localize-dates.js" defer></script>
+		{% include partials/analytics.html %}
 	</head>
 	<body data-typeface="system-ui">
 		{% include partials/header.html %}

--- a/src/_includes/layouts/page.html
+++ b/src/_includes/layouts/page.html
@@ -14,6 +14,7 @@
 			rel="stylesheet"
 		/>
 		<title>{{ title }} | Lunch.dev Community Calendar</title>
+		{% include partials/analytics.html %}
 	</head>
 	<body data-typeface="system-ui">
 		{% include partials/header.html %}

--- a/src/_includes/layouts/post.html
+++ b/src/_includes/layouts/post.html
@@ -13,6 +13,7 @@
 			rel="stylesheet"
 		/>
 		<title>{{ title }} | Lunch.dev Community Calendar</title>
+		{% include partials/analytics.html %}
 	</head>
 	<body data-typeface="system-ui">
 		{% include partials/header.html %}

--- a/src/_includes/partials/analytics.html
+++ b/src/_includes/partials/analytics.html
@@ -1,0 +1,1 @@
+<script src="https://cdn.usefathom.com/script.js" data-site="BDCMTTNP" defer></script>


### PR DESCRIPTION
i'd like to add analytics to get a better sense of how folks find, leave, and convert on the site

fathom does so in an ethical way, without cross-site tracking

this commit adds fathom analytics to all existing layouts:
- `event.html`
- `hopage.html`
- `page.html`
- `post.html`