### PR TITLE
Add analytics redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,2 +1,3 @@
 /discord https://discord.gg/dx7ZWCy
 /youtube https://www.youtube.com/channel/UCB5V77aiP0pz7RVbfQrbr7Q
+/analytics https://app.usefathom.com/share/bdcmttnp/events.lunch.dev


### PR DESCRIPTION
Add an easy redirect url for hosted, public analytics.

This is mostly for fun. In the spirit of openness, it felt like an interesting thing to enable and make public.